### PR TITLE
update fastly terraform plugin to 0.13 and improve terraform testing workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
+        env:
+          FASTLY_API_KEY: ${{ secrets.FASTLY_API_KEY }}
 
       - uses: actions/github-script@0.9.0
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,22 +2,58 @@ name: Test
 on: [pull_request]
 env:
   terraform_version: '0.12.29'
-  terraform_working_dir: 'fastly/terraform/'
+  terraform_working_dir: 'terraform/'
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.terraform_working_dir }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.4
-        with:
-          node-version: 12.x
-      - run: npm ci
-      - name: 'Terraform Format'
-        uses: hashicorp/terraform-github-actions@v0.8.0
-        with:
-          tf_actions_version: ${{ env.terraform_version }}
-          tf_actions_subcommand: 'fmt'
-          tf_actions_working_dir: ${{ env.terraform_working_dir }}
-          tf_actions_comment: true
+      - uses: hashicorp/setup-terraform@v1
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖${{ steps.validate.outputs.stdout }}
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`${process.env.PLAN}\`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.terraform_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on: [pull_request]
 env:
-  terraform_version: '0.12.29'
+  terraform_version: '0.13'
   terraform_working_dir: 'terraform/'
 jobs:
   test:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "fastly" {
-  version = "0.1.2"
+  version = "0.12.29"
 }
 
 resource "fastly_service_v1" "origami_imageset_data" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "fastly" {
-  version = "0.12.29"
+  version = "0.13"
 }
 
 resource "fastly_service_v1" "origami_imageset_data" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,4 @@
-provider "fastly" {
-  version = "0.13"
-}
+provider "fastly" {}
 
 resource "fastly_service_v1" "origami_imageset_data" {
   name = "Origami Imageset Data (github.com/Financial-Times/origami-imageset-data)"
@@ -49,17 +47,17 @@ resource "fastly_service_v1" "origami_imageset_data" {
 
   vcl {
     name    = "main.vcl"
-    content = "${file("${path.module}/../vcl/main.vcl")}"
+    content = file("${path.module}/../vcl/main.vcl")
     main    = true
   }
 
   vcl {
     name    = "fastly-boilerplate.vcl"
-    content = "${file("${path.module}/../vcl/fastly-boilerplate.vcl")}"
+    content = file("${path.module}/../vcl/fastly-boilerplate.vcl")
   }
 
   vcl {
     name    = "multi-region-routing.vcl"
-    content = "${file("${path.module}/../vcl/multi-region-routing.vcl")}"
+    content = file("${path.module}/../vcl/multi-region-routing.vcl")
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    fastly = {
+      source = "terraform-providers/fastly"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
The terraform configuration used a version of the fastly terraform plugin that was extremely old and no longer works with terraform.

I've needed to update terraform and the fastly plugin to versions which are compatible with eachother.

I've not updated to the latest version of the fastly plugin because that would introduce too many changes at once which I found overwhelming to check worked correctly. I've instead chosen to update to the lowest version which works with terraform, which is also the version that we use in other FT projects such as specialist and polyfill