### PR TITLE
increase the healthcheck timeout from 0.5 seconds to 5 seconds

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,6 +21,7 @@ resource "fastly_service_v1" "origami_imageset_data" {
     host           = "origami-imageset-data-us.s3.amazonaws.com"
     path           = "/__gtg"
     check_interval = 60000
+    timeout        = 5000
   }
 
   backend {
@@ -37,6 +38,7 @@ resource "fastly_service_v1" "origami_imageset_data" {
     host           = "origami-imageset-data-eu.s3.amazonaws.com"
     path           = "/__gtg"
     check_interval = 60000
+    timeout        = 5000
   }
 
   gzip {


### PR DESCRIPTION
Currently around 0.2% of requests end up returning a 503 because the healthchecks on both backends have reported the backends as being unhealthy. This is due to the short timeout of 0.5 seconds that we currently have on the healthchecks.

As these backends are s3 buckets with static files, we should either:
- Increase the timeout so that we have less likelihood of both backends being marked unhealthy at the same time
- Add a fallback backend which is the same s3 buckets but without a healthcheck applied so that it is never marked unhealthy by Fastly

I've gone with the first option because we are not going to keep these s3 buckets around for much longer and it requires the least amount of code and infra changes